### PR TITLE
Avoid Result<Result<>> nesting when linq syntax projects a Result over Select or SelectMany

### DIFF
--- a/src/DeFuncto.Core/DeFuncto.Core.csproj
+++ b/src/DeFuncto.Core/DeFuncto.Core.csproj
@@ -14,7 +14,7 @@
         <PackageTags>Functional Monad Option Result Either Parallel</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <PackageVersion>1.1.2</PackageVersion>
+        <PackageVersion>1.1.3</PackageVersion>
         <PackageReadmeFile>readme.md</PackageReadmeFile>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
     </PropertyGroup>

--- a/src/DeFuncto.Core/DeFuncto.Core.csproj
+++ b/src/DeFuncto.Core/DeFuncto.Core.csproj
@@ -9,7 +9,7 @@
         <Authors>Yeray Cabello</Authors>
         <Company>Yeray Cabello</Company>
         <Description>Simple functional library, aimed for simplicity and ease of maintenance, trying to mimic what F# has to offer in terms of error handling. Heavily inspired by language-ext</Description>
-        <Version>1.0.5</Version>
+        <Version>1.0.6</Version>
         <RepositoryUrl>https://github.com/JYCabello/DeFuncto</RepositoryUrl>
         <PackageTags>Functional Monad Option Result Either Parallel</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/DeFuncto.Core/Types/AsyncResult.cs
+++ b/src/DeFuncto.Core/Types/AsyncResult.cs
@@ -289,28 +289,36 @@ public readonly struct AsyncResult<TOk, TError>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public AsyncResult<TOk2, TError> Select<TOk2>(Func<TOk, TOk2> projection) => Map(projection);
 
-    /// <summary>
-    /// Binds and projects the present state using a binder and a projection
-    /// function.
-    /// </summary>
-    /// <remarks>
-    /// Used to enable LINQ embedded syntax, not meant for direct use.
-    /// </remarks>
-    /// <param name="binder">Binding function.</param>
-    /// <param name="projection">Projection.</param>
-    /// <typeparam name="TOkBind">Intermediate type of the binding.</typeparam>
-    /// <typeparam name="TOkFinal">Final type of the projection.</typeparam>
-    /// <returns>A new AsyncResult.</returns>
+    public AsyncResult<TOk2, TError> Select<TOk2>(Func<TOk, AsyncResult<TOk2, TError>> projection) => Map(projection).Flatten();
+
+    ///// <summary>
+    ///// Binds and projects the present state using a binder and a projection
+    ///// function.
+    ///// </summary>
+    ///// <remarks>
+    ///// Used to enable LINQ embedded syntax, not meant for direct use.
+    ///// </remarks>
+    ///// <param name="binder">Binding function.</param>
+    ///// <param name="projection">Projection.</param>
+    ///// <typeparam name="TOkBind">Intermediate type of the binding.</typeparam>
+    ///// <typeparam name="TOkFinal">Final type of the projection.</typeparam>
+    ///// <returns>A new AsyncResult.</returns>
+    //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+    //public AsyncResult<TOkFinal, TError> SelectMany<TOkBind, TOkFinal>(
+    //    Func<TOk, AsyncResult<TOkBind, TError>> binder,
+    //    Func<TOk, TOkBind, TOkFinal> projection
+    //) =>
+    //    Bind(ok => binder(ok).Map(okbind => (ok, okbind)))
+    //        .Match(
+    //            okTpl => Ok<TOkFinal, TError>(projection(okTpl.ok, okTpl.okbind)),
+    //            Error<TOkFinal, TError>
+    //        );
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public AsyncResult<TOkFinal, TError> SelectMany<TOkBind, TOkFinal>(
-        Func<TOk, AsyncResult<TOkBind, TError>> binder,
-        Func<TOk, TOkBind, TOkFinal> projection
-    ) =>
-        Bind(ok => binder(ok).Map(okbind => (ok, okbind)))
-            .Match(
-                okTpl => Ok<TOkFinal, TError>(projection(okTpl.ok, okTpl.okbind)),
-                Error<TOkFinal, TError>
-            );
+    Func<TOk, AsyncResult<TOkBind, TError>> binder,
+    Func<TOk, TOkBind, AsyncResult<TOkFinal, TError>> projection
+) => throw new NotImplementedException();
 
     /// <summary>
     /// True if it's Ok.

--- a/src/DeFuncto.Core/Types/AsyncResult.cs
+++ b/src/DeFuncto.Core/Types/AsyncResult.cs
@@ -289,36 +289,58 @@ public readonly struct AsyncResult<TOk, TError>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public AsyncResult<TOk2, TError> Select<TOk2>(Func<TOk, TOk2> projection) => Map(projection);
 
+    /// <summary>
+    /// Projects the Ok value.
+    /// </summary>
+    /// <remarks>
+    /// Used to enable LINQ embedded syntax, not meant for direct use.
+    /// </remarks>
+    /// <param name="projection">Projection.</param>
+    /// <typeparam name="TOk2">New value type.</typeparam>
+    /// <returns>A new AsyncResult.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public AsyncResult<TOk2, TError> Select<TOk2>(Func<TOk, AsyncResult<TOk2, TError>> projection) => Map(projection).Flatten();
 
-    ///// <summary>
-    ///// Binds and projects the present state using a binder and a projection
-    ///// function.
-    ///// </summary>
-    ///// <remarks>
-    ///// Used to enable LINQ embedded syntax, not meant for direct use.
-    ///// </remarks>
-    ///// <param name="binder">Binding function.</param>
-    ///// <param name="projection">Projection.</param>
-    ///// <typeparam name="TOkBind">Intermediate type of the binding.</typeparam>
-    ///// <typeparam name="TOkFinal">Final type of the projection.</typeparam>
-    ///// <returns>A new AsyncResult.</returns>
-    //[MethodImpl(MethodImplOptions.AggressiveInlining)]
-    //public AsyncResult<TOkFinal, TError> SelectMany<TOkBind, TOkFinal>(
-    //    Func<TOk, AsyncResult<TOkBind, TError>> binder,
-    //    Func<TOk, TOkBind, TOkFinal> projection
-    //) =>
-    //    Bind(ok => binder(ok).Map(okbind => (ok, okbind)))
-    //        .Match(
-    //            okTpl => Ok<TOkFinal, TError>(projection(okTpl.ok, okTpl.okbind)),
-    //            Error<TOkFinal, TError>
-    //        );
+    /// <summary>
+    /// Binds and projects the present state using a binder and a projection
+    /// function.
+    /// </summary>
+    /// <remarks>
+    /// Used to enable LINQ embedded syntax, not meant for direct use.
+    /// </remarks>
+    /// <param name="binder">Binding function.</param>
+    /// <param name="projection">Projection.</param>
+    /// <typeparam name="TOkBind">Intermediate type of the binding.</typeparam>
+    /// <typeparam name="TOkFinal">Final type of the projection.</typeparam>
+    /// <returns>A new AsyncResult.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public AsyncResult<TOkFinal, TError> SelectMany<TOkBind, TOkFinal>(
+        Func<TOk, AsyncResult<TOkBind, TError>> binder,
+        Func<TOk, TOkBind, TOkFinal> projection
+    ) =>
+        Bind(ok => binder(ok).Map(okbind => (ok, okbind)))
+            .Match(
+                okTpl => Ok<TOkFinal, TError>(projection(okTpl.ok, okTpl.okbind)),
+                Error<TOkFinal, TError>
+            );
 
+    /// <summary>
+    /// Binds and projects the present state using a binder and a projection
+    /// function.
+    /// </summary>
+    /// <remarks>
+    /// Used to enable LINQ embedded syntax, not meant for direct use.
+    /// </remarks>
+    /// <param name="binder">Binding function.</param>
+    /// <param name="projection">Projection.</param>
+    /// <typeparam name="TOkBind">Intermediate type of the binding.</typeparam>
+    /// <typeparam name="TOkFinal">Final type of the projection.</typeparam>
+    /// <returns>A new AsyncResult.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public AsyncResult<TOkFinal, TError> SelectMany<TOkBind, TOkFinal>(
     Func<TOk, AsyncResult<TOkBind, TError>> binder,
     Func<TOk, TOkBind, AsyncResult<TOkFinal, TError>> projection
-) => throw new NotImplementedException();
+    ) => Bind(ok => binder(ok).Map(okb => projection(ok, okb))).Flatten();
 
     /// <summary>
     /// True if it's Ok.

--- a/src/DeFuncto.Core/Types/Result.cs
+++ b/src/DeFuncto.Core/Types/Result.cs
@@ -153,7 +153,7 @@ public readonly struct Result<TOk, TError> : IEquatable<Result<TOk, TError>>
     public Result<TOkFinal, TError> SelectMany<TOkBind, TOkFinal>(
         Func<TOk, Result<TOkBind, TError>> binder,
         Func<TOk, TOkBind, Result<TOkFinal, TError>> projection
-    ) => throw new NotImplementedException();
+    ) => Match(ok => binder(ok).Match(okBind => projection(ok, okBind), Error<TOkFinal, TError>), Error<TOkFinal, TError>);
 
     /// <summary>
     /// Collapses the structure in an output value, choosing the adequate projection

--- a/src/DeFuncto.Core/Types/Result.cs
+++ b/src/DeFuncto.Core/Types/Result.cs
@@ -93,6 +93,7 @@ public readonly struct Result<TOk, TError> : IEquatable<Result<TOk, TError>>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Result<TOk2, TError> Select<TOk2>(Func<TOk, Result<TOk2, TError>> projection) => Match(ok => projection(ok), Error<TOk2, TError>);
+
     /// <summary>
     /// Projects the error value.
     /// </summary>
@@ -148,6 +149,11 @@ public readonly struct Result<TOk, TError> : IEquatable<Result<TOk, TError>>
         Func<TOk, TOkBind, TOkFinal> projection
     ) =>
         Bind(ok => binder(ok).Map(okbind => projection(ok, okbind)));
+
+    public Result<TOkFinal, TError> SelectMany<TOkBind, TOkFinal>(
+        Func<TOk, Result<TOkBind, TError>> binder,
+        Func<TOk, TOkBind, Result<TOkFinal, TError>> projection
+    ) => throw new NotImplementedException();
 
     /// <summary>
     /// Collapses the structure in an output value, choosing the adequate projection

--- a/src/DeFuncto.Core/Types/Result.cs
+++ b/src/DeFuncto.Core/Types/Result.cs
@@ -85,6 +85,15 @@ public readonly struct Result<TOk, TError> : IEquatable<Result<TOk, TError>>
     public Result<TOk2, TError> Select<TOk2>(Func<TOk, TOk2> projection) => Map(projection);
 
     /// <summary>
+    /// Projects the Ok value.
+    /// </summary>
+    /// <remarks>
+    /// Used to enable LINQ embedded syntax, not meant for direct use.
+    /// </remarks>
+    [Pure]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Result<TOk2, TError> Select<TOk2>(Func<TOk, Result<TOk2, TError>> projection) => Match(ok => projection(ok), Error<TOk2, TError>);
+    /// <summary>
     /// Projects the error value.
     /// </summary>
     /// <param name="projection">Projection.</param>

--- a/src/DeFuncto.Tests/Core/Types/AsyncResult/Linq.cs
+++ b/src/DeFuncto.Tests/Core/Types/AsyncResult/Linq.cs
@@ -52,45 +52,45 @@ public class Linq
     }
 
     [Property(DisplayName = "AsyncResult Select should project results")]
-    public void SelectProjectsResult()
+    public async void SelectProjectsResult()
     {
         // leave the type castings to ensure it's not returning a nested Result<Result...>>
 
-        ((AsyncResult<decimal, int>)(from _ in Ok<string, int>(string.Empty).Async() select Ok<decimal, int>(decimal.Zero).Async())).ShouldBeOk();
-        ((AsyncResult<string, int>)(from _ in Ok<string, int>(string.Empty).Async() select Ok<string, int>(string.Empty).Async())).ShouldBeOk();
+        await ((AsyncResult<decimal, int>)(from _ in Ok<string, int>(string.Empty).Async() select Ok<decimal, int>(decimal.Zero).Async())).ShouldBeOk();
+        await ((AsyncResult<string, int>)(from _ in Ok<string, int>(string.Empty).Async() select Ok<string, int>(string.Empty).Async())).ShouldBeOk();
 
-        ((AsyncResult<string, int>)(from _ in Ok<string, int>(string.Empty).Async() select Error<string, int>(1).Async())).ShouldBeError(1);
-        ((AsyncResult<string, int>)(from _ in Error<string, int>(1).Async() select Error<string, int>(2).Async())).ShouldBeError(1);
-        ((AsyncResult<string, int>)(from _ in Error<string, int>(1).Async() select Ok<string, int>(string.Empty).Async())).ShouldBeError(1);
+        await ((AsyncResult<string, int>)(from _ in Ok<string, int>(string.Empty).Async() select Error<string, int>(1).Async())).ShouldBeError(1);
+        await ((AsyncResult<string, int>)(from _ in Error<string, int>(1).Async() select Error<string, int>(2).Async())).ShouldBeError(1);
+        await ((AsyncResult<string, int>)(from _ in Error<string, int>(1).Async() select Ok<string, int>(string.Empty).Async())).ShouldBeError(1);
     }
 
     [Property(DisplayName = "AsyncResult SelectMany should project results")]
-    public void SelectManyProjectsResult()
+    public async void SelectManyProjectsResult()
     {
         // leave the type castings to ensure it's not returning a nested Result<Result...>>
 
-        ((AsyncResult<string, int>)(
+        await ((AsyncResult<string, int>)(
             from x in Ok<string, int>(string.Empty).Async()
             from y in Ok<string, int>(string.Empty).Async()
             from z in Ok<string, int>(string.Empty).Async()
             select Ok<string, int>("out").Async()))
             .ShouldBeOk("out");
 
-        ((AsyncResult<string, int>)(
+        await ((AsyncResult<string, int>)(
             from x in Ok<string, int>(string.Empty).Async()
             from y in Ok<string, int>(string.Empty).Async()
             from z in Ok<string, int>(string.Empty).Async()
             select Error<string, int>(1).Async()))
             .ShouldBeError(1);
 
-        ((AsyncResult<string, int>)(
+        await ((AsyncResult<string, int>)(
             from x in Ok<string, int>(string.Empty).Async()
             from y in Ok<string, int>(string.Empty).Async()
             from z in Error<string, int>(1).Async()
             select Error<string, int>(2).Async()))
             .ShouldBeError(1);
 
-        ((AsyncResult<decimal, int>)(
+        await ((AsyncResult<decimal, int>)(
             from x in Ok<string, int>(string.Empty).Async()
             from y in Ok<string, int>(string.Empty).Async()
             from z in Error<string, int>(1).Async()

--- a/src/DeFuncto.Tests/Core/Types/AsyncResult/Linq.cs
+++ b/src/DeFuncto.Tests/Core/Types/AsyncResult/Linq.cs
@@ -73,28 +73,28 @@ public class Linq
             from x in Ok<string, int>(string.Empty).Async()
             from y in Ok<string, int>(string.Empty).Async()
             from z in Ok<string, int>(string.Empty).Async()
-            select Ok<string, int>("out")))
+            select Ok<string, int>("out").Async()))
             .ShouldBeOk("out");
 
         ((AsyncResult<string, int>)(
             from x in Ok<string, int>(string.Empty).Async()
             from y in Ok<string, int>(string.Empty).Async()
             from z in Ok<string, int>(string.Empty).Async()
-            select Error<string, int>(1)))
+            select Error<string, int>(1).Async()))
             .ShouldBeError(1);
 
         ((AsyncResult<string, int>)(
-            from x in Ok<string, int>(string.Empty)
-            from y in Ok<string, int>(string.Empty)
-            from z in Error<string, int>(1)
-            select Error<string, int>(2)))
+            from x in Ok<string, int>(string.Empty).Async()
+            from y in Ok<string, int>(string.Empty).Async()
+            from z in Error<string, int>(1).Async()
+            select Error<string, int>(2).Async()))
             .ShouldBeError(1);
 
         ((AsyncResult<decimal, int>)(
-            from x in Ok<string, int>(string.Empty)
-            from y in Ok<string, int>(string.Empty)
-            from z in Error<string, int>(1)
-            select Error<decimal, int>(2)))
+            from x in Ok<string, int>(string.Empty).Async()
+            from y in Ok<string, int>(string.Empty).Async()
+            from z in Error<string, int>(1).Async()
+            select Error<decimal, int>(2).Async()))
             .ShouldBeError(1);
     }
 }

--- a/src/DeFuncto.Tests/Core/Types/AsyncResult/Linq.cs
+++ b/src/DeFuncto.Tests/Core/Types/AsyncResult/Linq.cs
@@ -52,49 +52,48 @@ public class Linq
     }
 
     [Property(DisplayName = "AsyncResult Select should project results")]
-    public async void SelectProjectsResult()
+    public void SelectProjectsResult()
     {
         // leave the type castings to ensure it's not returning a nested Result<Result...>>
 
-        await ((AsyncResult<decimal, int>)(from _ in Ok<string, int>(string.Empty).Async() select Ok<decimal, int>(decimal.Zero).Async())).ShouldBeOk();
-        await ((AsyncResult<string, int>)(from _ in Ok<string, int>(string.Empty).Async() select Ok<string, int>(string.Empty).Async())).ShouldBeOk();
-
-        await ((AsyncResult<string, int>)(from _ in Ok<string, int>(string.Empty).Async() select Error<string, int>(1).Async())).ShouldBeError(1);
-        await ((AsyncResult<string, int>)(from _ in Error<string, int>(1).Async() select Error<string, int>(2).Async())).ShouldBeError(1);
-        await ((AsyncResult<string, int>)(from _ in Error<string, int>(1).Async() select Ok<string, int>(string.Empty).Async())).ShouldBeError(1);
+        var _1 = ((AsyncResult<decimal, int>)(from _ in Ok<string, int>(string.Empty).Async() select Ok<decimal, int>(decimal.Zero).Async())).ShouldBeOk().Result;
+        var _2 = ((AsyncResult<string, int>)(from _ in Ok<string, int>(string.Empty).Async() select Ok<string, int>(string.Empty).Async())).ShouldBeOk().Result;
+        var _3 = ((AsyncResult<string, int>)(from _ in Ok<string, int>(string.Empty).Async() select Error<string, int>(1).Async())).ShouldBeError(1).Result;
+        var _4 = ((AsyncResult<string, int>)(from _ in Error<string, int>(1).Async() select Error<string, int>(2).Async())).ShouldBeError(1).Result;
+        var _5 = ((AsyncResult<string, int>)(from _ in Error<string, int>(1).Async() select Ok<string, int>(string.Empty).Async())).ShouldBeError(1).Result;
     }
 
     [Property(DisplayName = "AsyncResult SelectMany should project results")]
-    public async void SelectManyProjectsResult()
+    public void SelectManyProjectsResult()
     {
         // leave the type castings to ensure it's not returning a nested Result<Result...>>
 
-        await ((AsyncResult<string, int>)(
+        var _1 = ((AsyncResult<string, int>)(
             from x in Ok<string, int>(string.Empty).Async()
             from y in Ok<string, int>(string.Empty).Async()
             from z in Ok<string, int>(string.Empty).Async()
             select Ok<string, int>("out").Async()))
-            .ShouldBeOk("out");
+            .ShouldBeOk("out").Result;
 
-        await ((AsyncResult<string, int>)(
+        var _2 = ((AsyncResult<string, int>)(
             from x in Ok<string, int>(string.Empty).Async()
             from y in Ok<string, int>(string.Empty).Async()
             from z in Ok<string, int>(string.Empty).Async()
             select Error<string, int>(1).Async()))
-            .ShouldBeError(1);
+            .ShouldBeError(1).Result;
 
-        await ((AsyncResult<string, int>)(
+        var _3 = ((AsyncResult<string, int>)(
             from x in Ok<string, int>(string.Empty).Async()
             from y in Ok<string, int>(string.Empty).Async()
             from z in Error<string, int>(1).Async()
             select Error<string, int>(2).Async()))
-            .ShouldBeError(1);
+            .ShouldBeError(1).Result;
 
-        await ((AsyncResult<decimal, int>)(
+        var _4 = ((AsyncResult<decimal, int>)(
             from x in Ok<string, int>(string.Empty).Async()
             from y in Ok<string, int>(string.Empty).Async()
             from z in Error<string, int>(1).Async()
-            select Error<decimal, int>(2).Async()))
-            .ShouldBeError(1);
+            select Error<decimal, int>(2).Async()))            
+            .ShouldBeError(1).Result;
     }
 }

--- a/src/DeFuncto.Tests/Core/Types/AsyncResult/Linq.cs
+++ b/src/DeFuncto.Tests/Core/Types/AsyncResult/Linq.cs
@@ -50,4 +50,51 @@ public class Linq
 
         int Boom() => throw new Exception("Should not happen");
     }
+
+    [Property(DisplayName = "AsyncResult Select should project results")]
+    public void SelectProjectsResult()
+    {
+        // leave the type castings to ensure it's not returning a nested Result<Result...>>
+
+        ((AsyncResult<decimal, int>)(from _ in Ok<string, int>(string.Empty).Async() select Ok<decimal, int>(decimal.Zero).Async())).ShouldBeOk();
+        ((AsyncResult<string, int>)(from _ in Ok<string, int>(string.Empty).Async() select Ok<string, int>(string.Empty).Async())).ShouldBeOk();
+
+        ((AsyncResult<string, int>)(from _ in Ok<string, int>(string.Empty).Async() select Error<string, int>(1).Async())).ShouldBeError(1);
+        ((AsyncResult<string, int>)(from _ in Error<string, int>(1).Async() select Error<string, int>(2).Async())).ShouldBeError(1);
+        ((AsyncResult<string, int>)(from _ in Error<string, int>(1).Async() select Ok<string, int>(string.Empty).Async())).ShouldBeError(1);
+    }
+
+    [Property(DisplayName = "AsyncResult SelectMany should project results")]
+    public void SelectManyProjectsResult()
+    {
+        // leave the type castings to ensure it's not returning a nested Result<Result...>>
+
+        ((AsyncResult<string, int>)(
+            from x in Ok<string, int>(string.Empty).Async()
+            from y in Ok<string, int>(string.Empty).Async()
+            from z in Ok<string, int>(string.Empty).Async()
+            select Ok<string, int>("out")))
+            .ShouldBeOk("out");
+
+        ((AsyncResult<string, int>)(
+            from x in Ok<string, int>(string.Empty).Async()
+            from y in Ok<string, int>(string.Empty).Async()
+            from z in Ok<string, int>(string.Empty).Async()
+            select Error<string, int>(1)))
+            .ShouldBeError(1);
+
+        ((AsyncResult<string, int>)(
+            from x in Ok<string, int>(string.Empty)
+            from y in Ok<string, int>(string.Empty)
+            from z in Error<string, int>(1)
+            select Error<string, int>(2)))
+            .ShouldBeError(1);
+
+        ((AsyncResult<decimal, int>)(
+            from x in Ok<string, int>(string.Empty)
+            from y in Ok<string, int>(string.Empty)
+            from z in Error<string, int>(1)
+            select Error<decimal, int>(2)))
+            .ShouldBeError(1);
+    }
 }

--- a/src/DeFuncto.Tests/Core/Types/Result/Linq.cs
+++ b/src/DeFuncto.Tests/Core/Types/Result/Linq.cs
@@ -87,6 +87,8 @@ public class Linq
     [Property(DisplayName = "Result SelectMany should project results")]
     public void SelectManyProjectsResult()
     {
+        // leave the type castings to ensure it's not returning a nested Result<Result...>>
+
         ((Result<string, int>)(
             from x in Ok<string, int>(string.Empty)
             from y in Ok<string, int>(string.Empty)
@@ -94,5 +96,18 @@ public class Linq
             select Ok<string, int>("out")))
             .ShouldBeOk("out");
 
+        ((Result<string, int>)(
+            from x in Ok<string, int>(string.Empty)
+            from y in Ok<string, int>(string.Empty)
+            from z in Ok<string, int>(string.Empty)
+            select Error<string, int>(1)))
+            .ShouldBeError(1);
+
+        ((Result<string, int>)(
+            from x in Ok<string, int>(string.Empty)
+            from y in Ok<string, int>(string.Empty)
+            from z in Error<string, int>(1)
+            select Error<string, int>(2)))
+            .ShouldBeError(1);
     }
 }

--- a/src/DeFuncto.Tests/Core/Types/Result/Linq.cs
+++ b/src/DeFuncto.Tests/Core/Types/Result/Linq.cs
@@ -109,5 +109,12 @@ public class Linq
             from z in Error<string, int>(1)
             select Error<string, int>(2)))
             .ShouldBeError(1);
+
+        ((Result<decimal, int>)(
+            from x in Ok<string, int>(string.Empty)
+            from y in Ok<string, int>(string.Empty)
+            from z in Error<string, int>(1)
+            select Error<decimal, int>(2)))
+            .ShouldBeError(1);
     }
 }

--- a/src/DeFuncto.Tests/Core/Types/Result/Linq.cs
+++ b/src/DeFuncto.Tests/Core/Types/Result/Linq.cs
@@ -74,9 +74,13 @@ public class Linq
     [Property(DisplayName = "Result Select should project results")]
     public void SelectProjectsResult()
     {
-        (from _ in Ok<string, int>(string.Empty) select Ok<string, int>(string.Empty)).ShouldBeOk();
-        (from _ in Ok<string, int>(string.Empty) select Error<string, int>(1)).ShouldBeError(1);
-        (from _ in Error<string, int>(1) select Error<string, int>(2)).ShouldBeError(1);
-        (from _ in Error<string, int>(1) select Ok<string, int>(string.Empty)).ShouldBeError(1);
+        // leave the type castings to ensure it's not returning a nested Result<Result...>>
+        
+        ((Result<decimal, int>) (from _ in Ok<string, int>(string.Empty) select Ok<decimal,int>(decimal.Zero))).ShouldBeOk();
+        ((Result<string, int>) (from _ in Ok<string, int>(string.Empty) select Ok<string, int>(string.Empty))).ShouldBeOk();
+        
+        ((Result<string,int>) (from _ in Ok<string, int>(string.Empty) select Error<string, int>(1))).ShouldBeError(1);
+        ((Result<string,int>) (from _ in Error<string, int>(1) select Error<string, int>(2))).ShouldBeError(1);
+        ((Result<string,int>) (from _ in Error<string, int>(1) select Ok<string, int>(string.Empty))).ShouldBeError(1);
     }
 }

--- a/src/DeFuncto.Tests/Core/Types/Result/Linq.cs
+++ b/src/DeFuncto.Tests/Core/Types/Result/Linq.cs
@@ -83,4 +83,16 @@ public class Linq
         ((Result<string,int>) (from _ in Error<string, int>(1) select Error<string, int>(2))).ShouldBeError(1);
         ((Result<string,int>) (from _ in Error<string, int>(1) select Ok<string, int>(string.Empty))).ShouldBeError(1);
     }
+
+    [Property(DisplayName = "Result SelectMany should project results")]
+    public void SelectManyProjectsResult()
+    {
+        ((Result<string, int>)(
+            from x in Ok<string, int>(string.Empty)
+            from y in Ok<string, int>(string.Empty)
+            from z in Ok<string, int>(string.Empty)
+            select Ok<string, int>("out")))
+            .ShouldBeOk("out");
+
+    }
 }

--- a/src/DeFuncto.Tests/Core/Types/Result/Linq.cs
+++ b/src/DeFuncto.Tests/Core/Types/Result/Linq.cs
@@ -70,4 +70,13 @@ public class Linq
 
         int Boom() => throw new Exception("Should not happen");
     }
+
+    [Property(DisplayName = "Result Select should project results")]
+    public void SelectProjectsResult()
+    {
+        (from _ in Ok<string, int>(string.Empty) select Ok<string, int>(string.Empty)).ShouldBeOk();
+        (from _ in Ok<string, int>(string.Empty) select Error<string, int>(1)).ShouldBeError(1);
+        (from _ in Error<string, int>(1) select Error<string, int>(2)).ShouldBeError(1);
+        (from _ in Error<string, int>(1) select Ok<string, int>(string.Empty)).ShouldBeError(1);
+    }
 }


### PR DESCRIPTION
` from _ in Ok<string, int> select Ok<string, int> ` now returns Result<string, int> instead of Result<Result<string,int>,int>
Fixes #110 