### PR TITLE
Pin mise dotnet SDK to 10.0.302

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,2 @@
 [tools]
-dotnet = "10.0.300"
+dotnet = "10.0.302"


### PR DESCRIPTION
Bumps the mise-pinned .NET SDK from 10.0.300 to 10.0.302 (latest in the 10.0 line).